### PR TITLE
Support setting a checkpoint to go back to

### DIFF
--- a/src/action-types.js
+++ b/src/action-types.js
@@ -5,3 +5,4 @@ export const REPLACE = 'ROUTER_REPLACE';
 export const GO = 'ROUTER_GO';
 export const GO_BACK = 'ROUTER_GO_BACK';
 export const GO_FORWARD = 'ROUTER_GO_FORWARD';
+export const GO_BACK_TO_CHECKPOINT = 'ROUTER_GO_BACK_TO_CHECKPOINT';

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ import {
   REPLACE,
   GO,
   GO_FORWARD,
-  GO_BACK
+  GO_BACK,
+  GO_BACK_TO_CHECKPOINT
 } from './action-types';
 
 const Fragment = AbsoluteFragment;
@@ -48,6 +49,7 @@ export {
   GO,
   GO_FORWARD,
   GO_BACK,
+  GO_BACK_TO_CHECKPOINT,
 
   // Low-level Redux utilities
   routerReducer,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -24,8 +24,6 @@ export default ({ history }) => () => next => action => {
   case GO_FORWARD:
     history.goForward();
     break;
-  default:
-    // ...but we want to leave all events we don't care about undisturbed
-    return next(action);
   }
+  return next(action);
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -26,7 +26,7 @@ export default ({ history, getState }) => () => next => action => {
     history.goForward();
     break;
   case GO_BACK_TO_CHECKPOINT:
-    const checkPointCounter = getState().get(checkPointCounter);
+    const checkPointCounter = getState().get('checkPointCounter');
     history.go(-1*checkPointCounter);
     break;
   }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,13 +2,14 @@
 
 import {
   PUSH, REPLACE, GO,
-  GO_BACK, GO_FORWARD
+  GO_BACK, GO_FORWARD,
+  GO_BACK_TO_CHECKPOINT
 } from './action-types';
 
-export default ({ history }) => () => next => action => {
+export default ({ history, getState }) => () => next => action => {
   switch (action.type) {
   case PUSH:
-    history.push(action.payload);
+    history.push(action.payload.path ? action.payload.path : action.payload);
     // No return, no next() here
     // We stop all history events from progressing further through the dispatch chain...
     break;
@@ -23,6 +24,10 @@ export default ({ history }) => () => next => action => {
     break;
   case GO_FORWARD:
     history.goForward();
+    break;
+  case GO_BACK_TO_CHECKPOINT:
+    const checkPointCounter = getState().get(checkPointCounter);
+    history.go(-1*checkPointCounter);
     break;
   }
   return next(action);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -6,7 +6,7 @@ import {
   GO_BACK_TO_CHECKPOINT
 } from './action-types';
 
-export default ({ history, getState }) => () => next => action => {
+export default ({ history }) => (store) => next => action => {
   switch (action.type) {
   case PUSH:
     history.push(action.payload.path ? action.payload.path : action.payload);
@@ -26,7 +26,7 @@ export default ({ history, getState }) => () => next => action => {
     history.goForward();
     break;
   case GO_BACK_TO_CHECKPOINT:
-    const checkPointCounter = getState().get('checkPointCounter');
+    const checkPointCounter = store.getState().getIn(['router', 'checkPointCounter']);
     history.go(-1*checkPointCounter);
     break;
   }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -26,7 +26,7 @@ export default ({ history }) => (store) => next => action => {
     history.goForward();
     break;
   case GO_BACK_TO_CHECKPOINT:
-    const checkPointCounter = store.getState().getIn(['router', 'checkPointCounter']);
+    const checkPointCounter = store.getState().getIn(['router', 'checkPointCounter'], 0);
     history.go(-1*checkPointCounter);
     break;
   }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -24,7 +24,11 @@ export default (state: ?Location | Object = {}, action: Action) => {
     if (state) {
       if (state.get) {
         // state is an immutable object - use its constructor to make the next state
-        return state.constructor({previous: state.delete("previous"), basename: state.get("basename")}).merge(action.payload);
+        let base = {previous: state.delete("previous"), basename: state.get("basename")}
+        if (state.get('checkPointCounter') !== undefined){
+          base['checkPointCounter'] = state.get('checkPointCounter')
+        }
+        return state.constructor(base).merge(action.payload);
       }
       // eslint-disable-next-line no-unused-vars
       const { previous, ...oldState } = state;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,7 +1,7 @@
 // @flow
 import type { Action } from 'redux';
 import type { Location } from 'history';
-import { LOCATION_CHANGED } from './action-types';
+import {LOCATION_CHANGED, GO_BACK, PUSH, GO_BACK_TO_CHECKPOINT} from './action-types';
 
 export default (state: ?Location | Object = {}, action: Action) => {
   let get = (obj, prop) => obj[prop];
@@ -40,6 +40,21 @@ export default (state: ?Location | Object = {}, action: Action) => {
         ...nextState
       } : nextState;
     }
+  }
+  if (action.payload.checkPoint){
+    return state.set('checkPointCounter', 1)
+  }
+  let checkPointCounter = state.get('checkPointCounter')
+  if (checkPointCounter !== undefined){
+    if (action.type === GO_BACK){
+      return state.set('checkPointCounter', checkPointCounter-1)
+    }
+    if (action.type === PUSH){
+      return state.set('checkPointCounter', checkPointCounter+1)
+    }
+  }
+  if (action.type === GO_BACK_TO_CHECKPOINT){
+    return state.delete('checkPointCounter')
   }
   return state;
 };

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -41,20 +41,23 @@ export default (state: ?Location | Object = {}, action: Action) => {
       } : nextState;
     }
   }
-  if (action.payload.checkPoint){
-    return state.set('checkPointCounter', 1)
-  }
-  let checkPointCounter = state.get('checkPointCounter')
-  if (checkPointCounter !== undefined){
-    if (action.type === GO_BACK){
-      return state.set('checkPointCounter', checkPointCounter-1)
+  if (state.get){
+    if (action.payload && action.payload.checkPoint){
+      return state.set('checkPointCounter', 1)
     }
-    if (action.type === PUSH){
-      return state.set('checkPointCounter', checkPointCounter+1)
+    let checkPointCounter = state.get('checkPointCounter')
+    if (checkPointCounter !== undefined){
+      if (action.type === GO_BACK){
+        return state.set('checkPointCounter', checkPointCounter-1)
+      }
+      if (action.type === PUSH){
+        return state.set('checkPointCounter', checkPointCounter+1)
+      }
+    }
+    if (action.type === GO_BACK_TO_CHECKPOINT){
+      return state.delete('checkPointCounter')
     }
   }
-  if (action.type === GO_BACK_TO_CHECKPOINT){
-    return state.delete('checkPointCounter')
-  }
+
   return state;
 };


### PR DESCRIPTION
This is so we can, as part of a PUSH, set a checkpoint. This lets us go back to the location before we did the PUSH. This is done by adding support for a new action type, GO_BACK_TO_CHECKPOINT.